### PR TITLE
FIX: do not remove mindboggle args if no prov

### DIFF
--- a/mindboggle/mindboggle123
+++ b/mindboggle/mindboggle123
@@ -254,7 +254,7 @@ def mindboggle(subjectid, fsdir, antsdir, antsseg, out, prov, args,
 
     all_args = ' '.join([DATA, '--out', out, '--ants', ants,
                          '--working', os.getcwd()] +
-                        [args] + ['--prov'] if prov else [])
+                        [args] + (['--prov'] if prov else []))
 
     if num_threads > 1:
         all_args += ' --plugin MultiProc --plugin_args "dict(n_procs={0})"'.\
@@ -415,11 +415,7 @@ else:
     mbFlow.connect(corticalthickness, 'BrainSegmentation',
                    Mindboggle, 'antsseg')
 Mindboggle.inputs.out = mindboggle_output
-<<<<<<< HEAD
-Mindboggle.inputs.prov = False  # args.prov disable
-=======
 Mindboggle.inputs.prov = False # args.prov
->>>>>>> 66144b0f47b9b3294361cdbf440d768c9252b5cb
 Mindboggle.inputs.args = '--roygbiv'  # ' --graph hier'
 if args.mb_num_threads:
     Mindboggle.inputs.num_threads = args.mb_num_threads

--- a/mindboggle/mindboggle123
+++ b/mindboggle/mindboggle123
@@ -329,7 +329,7 @@ else:
         transformer_nn = Node(ApplyTransforms(), name="transformer_nn")
         transformer_nn.inputs.reference_image = IMAGE
         transformer_nn.inputs.dimension = 3
-        transformer_nn.inputs.invert_transform_flags = [False, False]
+        transformer_nn.inputs.invert_transform_flags = [False] * N
         transformer_nn.inputs.input_image = '/opt/data/OASIS-TRT-20_jointfusion_DKT31_CMA_labels_in_OASIS-30_v2.nii.gz'
         transformer_nn.inputs.interpolation = 'NearestNeighbor'
 
@@ -346,7 +346,7 @@ else:
         reg = MapNode(Registration(), iterfield=['moving_image'],
                       name="register")
         reg.inputs.moving_image = T1s[:N]
-        
+
         # mimic fmriprep's T1 - MNI registration
         reg.inputs.dimension = 3
         reg.inputs.convergence_threshold = [1e-06, 1e-06, 1e-06]

--- a/mindboggle/mindboggle123
+++ b/mindboggle/mindboggle123
@@ -416,7 +416,7 @@ else:
     mbFlow.connect(corticalthickness, 'BrainSegmentation',
                    Mindboggle, 'antsseg')
 Mindboggle.inputs.out = mindboggle_output
-# Mindboggle.inputs.prov = args.prov
+Mindboggle.inputs.prov = False  # args.prov disable
 Mindboggle.inputs.args = '--roygbiv'  # ' --graph hier'
 if args.mb_num_threads:
     Mindboggle.inputs.num_threads = args.mb_num_threads


### PR DESCRIPTION
`all_args` was being set to `''` when `prov == True`